### PR TITLE
Don't generate signals on edgecases

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,7 +27,7 @@ jobs:
       run: poetry install
     - name: check format with black
       run: |
-        poetry run black --diff .
+        poetry run black --check .
     - name: check import order with isort
       run: |
         poetry run isort -c .

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -15,3 +15,12 @@ def test_switch_simple():
 
     TrackSignalGenerator(topology).place_switch_signals()
     assert len(topology.signals.keys()) == 3
+
+def test_switch_both():
+    topology = load(open("tests/topologies/switch_simple.pickle", "rb"))
+
+    tsg = TrackSignalGenerator(topology)
+    tsg.place_switch_signals()
+    tsg.place_edge_signals()
+
+    assert len(topology.signals.keys()) == 4

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -16,6 +16,7 @@ def test_switch_simple():
     TrackSignalGenerator(topology).place_switch_signals()
     assert len(topology.signals.keys()) == 3
 
+
 def test_switch_both():
     topology = load(open("tests/topologies/switch_simple.pickle", "rb"))
 

--- a/track_signal_generator/generator.py
+++ b/track_signal_generator/generator.py
@@ -46,7 +46,9 @@ class TrackSignalGenerator:
                 )
 
     def _place_signals_on_edge(self, edge: Edge):
-        first_signal = 1 if not edge.node_a.is_switch() else DISTANCE_BEETWEEN_TRACK_SIGNALS
+        first_signal = (
+            1 if not edge.node_a.is_switch() else DISTANCE_BEETWEEN_TRACK_SIGNALS
+        )
         for track_meter in range(
             first_signal, int(edge.length), DISTANCE_BEETWEEN_TRACK_SIGNALS
         ):  # we start at 1 as otherwise sumo gets confused and adds a steep turn

--- a/track_signal_generator/generator.py
+++ b/track_signal_generator/generator.py
@@ -46,8 +46,9 @@ class TrackSignalGenerator:
                 )
 
     def _place_signals_on_edge(self, edge: Edge):
+        first_signal = 1 if not edge.node_a.is_switch() else DISTANCE_BEETWEEN_TRACK_SIGNALS
         for track_meter in range(
-            1, int(edge.length), DISTANCE_BEETWEEN_TRACK_SIGNALS
+            first_signal, int(edge.length), DISTANCE_BEETWEEN_TRACK_SIGNALS
         ):  # we start at 1 as otherwise sumo gets confused and adds a steep turn
             self._place_signal_on_edge(edge, track_meter)
 


### PR DESCRIPTION
Currently signals are generated on the switch as the new edge starts directly at the node (which results in a signal being created there) 